### PR TITLE
Fix loader bug and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# TermPresenter
+
+TermPresenter is a presentation tool that works entirely inside a terminal. It converts text and image slides into ASCII art so you can present over SSH, serial consoles or any other terminal connection.
+
+## Requirements
+- Ruby
+- Pango library for Ruby
+- netpbm utilities (for image conversion)
+- standard UNIX tools such as `cut`
+
+## Installation
+```bash
+git clone https://github.com/ikegam/Termpresenter.git
+cd Termpresenter
+chmod +x ./tmptr
+./tmptr -h
+```
+
+## Usage
+Slides are stored as files inside the `presen/` directory. Run `./tmptr` to start the presentation. Use the following keys while running:
+
+- `n` : next page
+- `p` : previous page
+- `c` : execute command
+- `l` : reload slides from directory
+- `q` : quit
+
+## Directory layout
+- `presen/` – sample presentation files
+- `lib/` – application libraries
+- `tmptr` – launcher script
+

--- a/lib/aastring.rb
+++ b/lib/aastring.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # このふぁいるはうーてーえふはちです。
 
 class String

--- a/lib/termpresenter.rb
+++ b/lib/termpresenter.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'aastring.rb'
 require 'curses'
@@ -31,7 +31,7 @@ class Tmptr_slide
       temp.write(@page_raw_data)
       temp.close
       return %x{cat #{temp.path}| jpegtopnm | ppmtopgm | pgmtopbm | pbmtoascii}
-    when :"image/jpeg"
+    when :"image/gif"
       temp.write(@page_raw_data)
       temp.close
       return %x{cat #{temp.path}| giftopnm | ppmtopgm | pgmtopbm | pbmtoascii}

--- a/lib/termpresenter_file_loader.rb
+++ b/lib/termpresenter_file_loader.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 class Tmptr_raw_page
 
@@ -10,7 +10,7 @@ class Tmptr_raw_page
   def initialize(file)
     @type = MIME::Types.type_for(file)[0].to_s.to_sym
     case @type
-    when :"text/plane"
+    when :"text/plain"
       @content = open(file).read
     else
       @content = open(file, "rb").read

--- a/tmptr
+++ b/tmptr
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 ENV['LANG'] = "C"
 $:.push("./lib")


### PR DESCRIPTION
## Summary
- fix typos for MIME type handling and gif slides
- use `/usr/bin/env ruby` in all scripts for portability
- add English `README.md`

## Testing
- `ruby -c lib/termpresenter.rb`
- `ruby -c lib/termpresenter_file_loader.rb`
- `ruby -c lib/aastring.rb`
- `ruby -c tmptr`


------
https://chatgpt.com/codex/tasks/task_b_68611e3427988332a296be21f1fac07e