### PR TITLE
Improve Ruby project structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/README
+++ b/README
@@ -30,8 +30,8 @@ Debianの場合
  # aptitude install coreutils ruby1.8 libpango1-ruby1.8 netpbm git-core
  $ git clone git://github.com/ikegam/Termpresenter.git
  $ cd Termpresenter/
- $ chmod +x ./tmptr
- $ ./tmptr
+ $ chmod +x ./bin/tmptr
+ $ ./bin/tmptr
 
 **コツ
 端末にセットするフォントはなるべく小さく、又端末の行間はなるべく少なめに設定した

--- a/README.en
+++ b/README.en
@@ -11,8 +11,8 @@
 **installation and start
  $ git clone git://github.com/ikegam/Termpresenter.git
  $ cd Termpresenter/
- $ chmod +x ./tmptr
- $ ./tmptr
+ $ chmod +x ./bin/tmptr
+ $ ./bin/tmptr
 
 **dir
 -presen/

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ TermPresenter is a presentation tool that works entirely inside a terminal. It c
 ```bash
 git clone https://github.com/ikegam/Termpresenter.git
 cd Termpresenter
-chmod +x ./tmptr
-./tmptr -h
+chmod +x ./bin/tmptr
+./bin/tmptr -h
 ```
 
 ## Usage
-Slides are stored as files inside the `presen/` directory. Run `./tmptr` to start the presentation. Use the following keys while running:
+Slides are stored as files inside the `presen/` directory. Run `./bin/tmptr` to start the presentation. Use the following keys while running:
 
 - `n` : next page
 - `p` : previous page
@@ -28,5 +28,5 @@ Slides are stored as files inside the `presen/` directory. Run `./tmptr` to star
 ## Directory layout
 - `presen/` – sample presentation files
 - `lib/` – application libraries
-- `tmptr` – launcher script
+- `bin/tmptr` – launcher script
 

--- a/bin/tmptr
+++ b/bin/tmptr
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
 ENV['LANG'] = "C"
-$:.push("./lib")
+$LOAD_PATH << File.expand_path("../lib", __dir__)
 
-require 'termpresenter_file_loader.rb'
-require 'termpresenter.rb'
+require 'termpresenter_file_loader'
+require 'termpresenter'
 
 require 'optparse'
 

--- a/lib/termpresenter.rb
+++ b/lib/termpresenter.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'aastring.rb'
+require_relative 'aastring'
 require 'curses'
 
 class Tmptr_slide
@@ -198,7 +198,7 @@ class Tmptr_result_window < Tmptr_sub_window_core
 end
 
 if $0 == __FILE__
-  require 'termpresenter_file_loader.rb'
+  require_relative 'termpresenter_file_loader'
 
   content = Tmptr_content.new_bydir("../presen/")
   tmptr = Tmptr.new(content)

--- a/termpresenter.gemspec
+++ b/termpresenter.gemspec
@@ -1,0 +1,15 @@
+Gem::Specification.new do |spec|
+  spec.name          = "termpresenter"
+  spec.version       = "0.1.0"
+  spec.summary       = "Terminal presentation tool"
+  spec.description   = "TermPresenter converts slides to ASCII art for terminal presentations."
+  spec.authors       = ["ikegam"]
+  spec.email         = ["example@example.com"]
+  spec.files         = Dir["lib/**/*", "bin/*", "presen/**/*", "README*"]
+  spec.executables   = ["tmptr"]
+  spec.bindir        = "bin"
+  spec.required_ruby_version = ">= 2.5"
+  spec.add_runtime_dependency "pango"
+  spec.add_runtime_dependency "mime-types"
+end
+


### PR DESCRIPTION
## Summary
- move launcher script into `bin/`
- fix requires to use `require_relative`
- update README docs for new executable path
- add Gemfile and gemspec for Ruby conventions

## Testing
- `ruby -c bin/tmptr`
- `ruby -c lib/termpresenter.rb`
- `ruby -c lib/termpresenter_file_loader.rb`
- `ruby -c lib/aastring.rb`
- `bundle check` *(fails: Gem::Net::HTTPClientException 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68611ff87e1c8332a7b3f9ddbe012868