### PR TITLE
Refactor to idiomatic Ruby

### DIFF
--- a/lib/aastring.rb
+++ b/lib/aastring.rb
@@ -11,26 +11,25 @@ class String
     @aafont = "IPAGothic"
   end
 
-  def to_aa(height=12)
-    ret = ""
-    self.split(/\n/).each{|line|
-      surface = Cairo::ImageSurface.new(Cairo::FORMAT_ARGB32, 400, height + (height/3).to_f)
+  def to_aa(height = 12)
+    each_line.reduce(+'') do |buf, line|
+      surface = Cairo::ImageSurface.new(Cairo::FORMAT_ARGB32, 400, height + (height / 3.0))
       context = Cairo::Context.new(surface)
       context.set_source_rgb(1, 1, 1)
-      context.rectangle(0, 0, 400, height + (height/3).to_f)
+      context.rectangle(0, 0, 400, height + (height / 3.0))
       context.fill
       context = Cairo::Context.new(surface)
       layout = context.create_pango_layout
-      layout.text = line
+      layout.text = line.chomp
       layout.font_description = "#{@aafont} #{height}"
       layout.width = 400 * Pango::SCALE
       context.show_pango_layout(layout)
-      temp = Tempfile.new("termpresenter", "/tmp")
-      surface.write_to_png(temp.path)
-      ret = ret + %x{cat #{temp.path}| pngtopnm | ppmtopgm | pgmtopbm | pbmtoascii}
-      temp.close
-    }
-    return ret
+      Tempfile.open('termpresenter', '/tmp') do |temp|
+        surface.write_to_png(temp.path)
+        buf << %x{cat #{temp.path}| pngtopnm | ppmtopgm | pgmtopbm | pbmtoascii}
+      end
+      buf
+    end
   end
 
 end

--- a/lib/termpresenter_file_loader.rb
+++ b/lib/termpresenter_file_loader.rb
@@ -8,13 +8,12 @@ class Tmptr_raw_page
   attr_reader :type
 
   def initialize(file)
-    @type = MIME::Types.type_for(file)[0].to_s.to_sym
-    case @type
-    when :"text/plain"
-      @content = open(file).read
-    else
-      @content = open(file, "rb").read
-    end
+    @type = MIME::Types.type_for(file).first.to_s.to_sym
+    @content = if @type == :"text/plain"
+                 File.read(file)
+               else
+                 File.binread(file)
+               end
   end
 
 end
@@ -23,8 +22,11 @@ class Tmptr_content
   attr_reader :pages
 
   def self.new_bydir(dir)
-    files = Dir.entries(dir).sort.map{|x| File.expand_path(x, dir)}.select{|x| File.ftype(x) == "file"}
-    self.new(files)
+    files = Dir.entries(dir)
+               .sort
+               .map { |x| File.expand_path(x, dir) }
+               .select { |x| File.file?(x) }
+    new(files)
   end
 
   def initialize(files)


### PR DESCRIPTION
## Summary
- refactor slide conversion pipeline with a cleaner Tempfile block
- simplify font calculations and terminal loop logic
- clean up string to AA conversion
- streamline content loader file handling

## Testing
- `ruby -c lib/termpresenter.rb`
- `ruby -c lib/termpresenter_file_loader.rb`
- `ruby -c lib/aastring.rb`


------
https://chatgpt.com/codex/tasks/task_b_6861259eb35483329b0f43547da1ad88